### PR TITLE
Upcoming breaking changes in `loo_compare()` output

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,5 @@
 ^NEWS\.md$
 ^.*\.md$
 ^.github/*
+^\.positai$
+^\.claude$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,20 +1,24 @@
 Package: BAMBI
 Type: Package
 Title: Bivariate Angular Mixture Models
-Version: 2.3.6
-Date: 2024-10-24
+Version: 2.3.7
+Date: 2026-05-05
 Authors@R: c(person(given = "Saptarshi",
                       family = "Chakraborty",
                       role = c("aut", "cre"),
                       email = "chakra.saptarshi@gmail.com"),
                person(given = c("Samuel", "W.K."),
                       family = "Wong",
-                      role = "aut"))
+                      role = "aut"),
+               person(given = "Florence",
+                      family = "Bockting",
+                      role = "ctb", 
+                      comment = "Patch for compatibility with {loo}"))
 Maintainer: Saptarshi Chakraborty <chakra.saptarshi@gmail.com>
 Description: Fit (using Bayesian methods) and simulate mixtures of univariate and bivariate angular distributions. Chakraborty and Wong (2021) <doi:10.18637/jss.v099.i11>.
 License: GPL-3
 LazyData: TRUE
-RoxygenNote: 7.3.2.9000
+RoxygenNote: 7.3.3
 LinkingTo: Rcpp,
            RcppArmadillo
 Imports: stats,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# BAMBI 2.3.7
+* updated compatibility with upcoming changes to `loo_compare()` output
+  structure in the `loo` package (> 2.9.0), which now returns a data frame
+  instead of a matrix and includes additional diagnostic columns.
+
 # BAMBI 2.1.0
 * fixed bugs that were causing some examples to fail 
 (due to an update in package loo)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # BAMBI 2.3.7
 * updated compatibility with upcoming changes to `loo_compare()` output
   structure in the `loo` package (> 2.9.0), which now returns a data frame
-  instead of a matrix and includes additional diagnostic columns.
+  instead of a matrix and includes additional diagnostic columns (thanks to @florence-bockting).
 
 # BAMBI 2.1.0
 * fixed bugs that were causing some examples to fail 

--- a/R/all_model_select.R
+++ b/R/all_model_select.R
@@ -507,11 +507,17 @@ fit_incremental_angmix <- function(model, data,
           x = crit_list
         )
 
-        E_diff <-  (
-          compare_crit_obj["comp_j", "elpd_diff"]
-          - compare_crit_obj["comp_j_minus_1", "elpd_diff"]
-        )
-        E_diff_se <- sum(compare_crit_obj[, "se_diff"])
+        if ("model" %in% colnames(compare_crit_obj)) {
+          idx_curr <- which(compare_crit_obj$model == "comp_j")
+          idx_prev <- which(compare_crit_obj$model == "comp_j_minus_1")
+        } else {
+          idx_curr <- which(rownames(compare_crit_obj) == "comp_j")
+          idx_prev <- which(rownames(compare_crit_obj) == "comp_j_minus_1")
+        }
+
+        E_diff <- compare_crit_obj[idx_curr, "elpd_diff"] -
+          compare_crit_obj[idx_prev, "elpd_diff"]
+        E_diff_se <- sum(compare_crit_obj[c(idx_curr, idx_prev), "se_diff"])
 
         if (abs(E_diff) < 4) {
           E_diff_se <- 2 * E_diff_se

--- a/cran_comments.md
+++ b/cran_comments.md
@@ -1,3 +1,43 @@
+# BAMBI v2.3.7
+
+## Resubmission
+
+This is a re-submission, with patches to ensure compatibility with upcoming changes to `loo_compare()` output structure in the `loo` package (> 2.9.0)
+
+## Changelog
+
+- updated compatibility with upcoming changes to `loo_compare()` output
+  structure in the `loo` package (> 2.9.0), which now returns a data frame
+  instead of a matrix and includes additional diagnostic columns (thanks to @florence-bockting).
+
+
+
+## Test environment:
+
+- local Windows 11 install, R version 4.6.0 (2026-04-24 ucrt)
+
+- local Ubuntu release 24.04, R version 4.5.2 (2025-10-31)
+
+- online win-builder (devel, release, and old release)
+
+- online mac-builder at mac.r-project.org (devel, release)
+
+
+
+## R CMD check results
+
+There were no ERRORs or WARNINGs in any platforms, and no NOTES on local Windows, online mac-builder and online win-builder (release, old-release, devel).
+
+There was a NOTE on Ubuntu 20.04 about the installed size of the installed package: 
+```
+❯ checking installed package size ... NOTE
+    installed size is 12.4Mb
+    sub-directories of 1Mb or more:
+      libs  11.9Mb
+```
+
+
+
 # BAMBI v2.3.6
 
 


### PR DESCRIPTION
## Description
In the `loo` package, we are making changes to the output structure returned by `loo_compare()` in [PR #300](https://github.com/stan-dev/loo/pull/300). The main changes are a transition from a matrix to a data frame and the addition of several new columns. Here is an example of the updated output structure:

```
> loo_compare(w1, w2)
  model elpd_diff se_diff p_worse diag_diff diag_elpd
 model1       0.0     0.0      NA                    
 model2      -4.1     0.1    1.00   N < 100   
        
Diagnostic flags present.
See ?`loo-glossary` (sections `diag_diff` and `diag_elpd`)
or https://mc-stan.org/loo/reference/loo-glossary.html.
```

More context on the motivation behind these changes can be found in the updated case study ["Uncertainty in Bayesian LOO-CV Model Comparison"](https://users.aalto.fi/~ave/casestudies/LOO_uncertainty/loo_uncertainty.html).

A **reverse dependency check revealed that these changes will affect your package**. To help smooth the transition, I have already reviewed your code and suggest within this PR changes that should keep your package compatible with both the current and the upcoming `loo_compare()` output structure.

I may have missed some additional spots in your code that need updating, so please feel free to point those out and I am happy to help. Thank you and please do not hesitate to reach out if you have any questions or concerns.